### PR TITLE
Update banyan-windows.ps1

### DIFF
--- a/banyan-windows.ps1
+++ b/banyan-windows.ps1
@@ -69,7 +69,6 @@ function create_config() {
         mdm_device_ownership = "C"
         mdm_ca_certs_preinstalled = $false
         mdm_skip_cert_suppression = $false
-        mdm_present = $true
         mdm_vendor_name = "Intune"
         mdm_start_at_boot = $true
         mdm_hide_on_start = $true


### PR DESCRIPTION
Remove "mdm_present" parameter as this value is currently only used in WS1 deployments for device trustcoring
