### PR TITLE
Installer script for Linux machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In the Banyan Command Center, navigate to **Settings** > **App Deployment**. Not
 The script will:
 1. Create an `mdm-config.json` file that specifies app functionality
 2. Download the *latest Banyan app* version and install it (you can also optionally specify an exact app version)
-3. Stage the app with the device certificate
+3. Stage the app with the device certificate (on Windows and MacOS)
 4. Start the app as the logged-on user
 
 
@@ -32,6 +32,14 @@ Launch PowerShell as Administrator and run:
 
 ```powershell
 .\banyan-windows.ps1 <INVITE_CODE> <DEPLOYMENT_KEY> <APP_VERSION (optional)>
+```
+
+### Linux
+
+Launch a terminal and run:
+
+```bash
+sudo ./banyan-linux.sh <INVITE_CODE> <APP_VERSION (optional)>
 ```
 
 
@@ -61,6 +69,15 @@ Launch PowerShell as Administrator and run:
 .\banyan-windows.ps1 upgrade upgrade <APP_VERSION (optional)>
 ```
 
+### Linux
+
+Launch a terminal and run:
+
+```bash
+sudo ./banyan-linux.sh upgrade <APP_VERSION (optional)>
+```
+
+---
 
 ## Notes for usage with Device Managers
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Automate installation of Banyan App on end-user devices.
 
 See [Banyan documentation](https://docs.banyansecurity.io/docs/feature-guides/manage-users-and-devices/device-managers/distribute-desktopapp/) for more details.
 
+---
 
 ## Install using Zero Touch Flow
 
@@ -14,7 +15,7 @@ In the Banyan Command Center, navigate to **Settings** > **App Deployment**. Not
 The script will:
 1. Create an `mdm-config.json` file that specifies app functionality
 2. Download the *latest Banyan app* version and install it (you can also optionally specify an exact app version)
-3. Stage the app with the device certificate (on Windows and MacOS)
+3. Stage the app with the device certificate
 4. Start the app as the logged-on user
 
 
@@ -41,7 +42,9 @@ Launch a terminal and run:
 ```bash
 sudo ./banyan-linux.sh <INVITE_CODE> <APP_VERSION (optional)>
 ```
+Note that the Linux script doesn't stage the app with the device certificate or start it up.
 
+---
 
 ## Upgrade Flow
 
@@ -76,6 +79,7 @@ Launch a terminal and run:
 ```bash
 sudo ./banyan-linux.sh upgrade <APP_VERSION (optional)>
 ```
+Note that the Linux script doesn't start up the app.
 
 ---
 

--- a/banyan-linux.sh
+++ b/banyan-linux.sh
@@ -97,10 +97,9 @@ function check_error {
 
 # Prepare to install dependencies
 function install_deps_prepare {
-  # try to locate yum, fall back to apt-get
   if [[ $(command -v yum) ]]; then
-    sudo yum clean metadata
-    check_error "sudo yum clean metadata"
+    sudo yum check-update
+    check_error "sudo yum check-update"
   else
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q=2 update
     check_error "sudo apt-get update"
@@ -119,7 +118,6 @@ function install_deps {
   else
     sudo DEBIAN_FRONTEND=noninteractive apt-get -q=2 -y install "${deps[@]}"
     check_error "sudo apt-get install ${deps[*]}"
-    setup_cgroup
   fi
 }
 
@@ -147,10 +145,11 @@ function download_install() {
 
     echo "Run installer"
     if [[ $(command -v yum) ]]; then
-        sudo rpm -i "${dl_file}"
+        sudo yum localinstall -y "${dl_file}"
+        check_error "sudo yum localinstall ${dl_file}"        
     else
-        install_deps gconf2 gconf-service libappindicator1 libnss3-tools wireguard-tools
-        sudo dpkg -i "${dl_file}"
+        sudo apt-get install "${dl_file}"
+        check_error "sudo apt-get install ${dl_file}"
     fi
     sleep 3
 }
@@ -158,7 +157,7 @@ function download_install() {
 
 function start_app() {
     echo "Starting the Banyan app as: $logged_on_user"
-    sudo -H -u "${logged_on_user}" /opt/Banyan/banyanapp
+    sudo -u "${logged_on_user}" /opt/Banyan/banyanapp
     sleep 5
 }
 

--- a/banyan-linux.sh
+++ b/banyan-linux.sh
@@ -7,8 +7,7 @@
 # Deployment Information
 # Obtain from the Banyan admin console: Settings > App Deployment
 INVITE_CODE="$1"
-DEPLOYMENT_KEY="$2"
-APP_VERSION="$3"
+APP_VERSION="$2"
 
 # Device Registration and Banyan App Configuration
 # Check docs for more options and details:
@@ -38,9 +37,9 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 
-if [[ -z "$INVITE_CODE" || -z "$DEPLOYMENT_KEY" ]]; then
+if [[ -z "$INVITE_CODE" ]]; then
     echo "Usage: "
-    echo "$0 <INVITE_CODE> <DEPLOYMENT_KEY> <APP_VERSION (optional>"
+    echo "$0 <INVITE_CODE> <APP_VERSION (optional>"
     exit 1
 fi
 
@@ -151,7 +150,7 @@ function stop_app() {
 }
 
 
-if [[ "$INVITE_CODE" = "upgrade" && "$DEPLOYMENT_KEY" = "upgrade" ]]; then
+if [[ "$INVITE_CODE" = "upgrade" ]]; then
     echo "Running upgrade flow"
     stop_app
     download_install

--- a/banyan-linux.sh
+++ b/banyan-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-# Banyan Zero Touch Installation
+# Banyan App Installation for Linux
 # Confirm or update the following variables prior to running the script
 
 # Deployment Information
@@ -9,24 +9,8 @@
 INVITE_CODE="$1"
 APP_VERSION="$2"
 
-# Device Registration and Banyan App Configuration
-# Check docs for more options and details:
-# https://docs.banyansecurity.io/docs/feature-guides/manage-users-and-devices/device-managers/distribute-desktopapp/#mdm-config-json
-DEVICE_OWNERSHIP="C"
-CA_CERTS_PREINSTALLED=false
-SKIP_CERT_SUPPRESSION=false
-VENDOR_NAME=""
-HIDE_SERVICES=false
-DISABLE_QUIT=false
-START_AT_BOOT=true
-HIDE_ON_START=true
-DISABLE_AUTO_UPDATE=false
-
-# Device Certificate management isn't supported on Linux
-
-
-
-
+# Device Registration, Banyan App Configuration, and
+# Device Certificate management should be handled by user
 
 ################################################################################
 
@@ -43,16 +27,22 @@ if [[ -z "$INVITE_CODE" ]]; then
     exit 1
 fi
 
+
+echo "Ensure curl is present"
+if [[ $(command -v yum) ]]; then
+    sudo yum install -y curl
+else
+    sudo apt-get install -y curl
+fi
+
+
 if [[ -z "$APP_VERSION" ]]; then
     echo "Checking for latest version of app"
     loc=$( curl -sI https://www.banyanops.com/app/linux/v3/latest-deb | awk '/Location:/ {print $2}' )
     APP_VERSION=$( awk -F'banyanapp_|_amd64.deb' '{print $2}' <<< "$loc" )
 fi
 
-
-
 echo "Installing with invite code: $INVITE_CODE"
-echo "Installing using deploy key: *****"
 echo "Installing app version: $APP_VERSION"
 
 logged_on_user=$( users | awk '{ print $1 }' )
@@ -62,72 +52,8 @@ global_config_dir="/etc/banyanapp"
 tmp_dir="/etc/banyanapp/tmp"
 mkdir -p "$tmp_dir"
 
-
-function create_config() {
-    echo "Creating mdm-config json file"
-    global_config_file="${global_config_dir}/mdm-config.json"
-
-    mdm_config_json='{
-        "mdm_invite_code": '"\"${INVITE_CODE}\""',
-        "mdm_deploy_user": '"\"${MY_USER}\""',
-        "mdm_deploy_email": '"\"${MY_EMAIL}\""',
-        "mdm_device_ownership": '"\"${DEVICE_OWNERSHIP}\""',
-        "mdm_ca_certs_preinstalled": '"${CA_CERTS_PREINSTALLED}"',
-        "mdm_skip_cert_suppression": '"${SKIP_CERT_SUPPRESSION}"',
-        "mdm_vendor_name": '"\"${VENDOR_NAME}\""',
-        "mdm_hide_services": '"${HIDE_SERVICES}"',
-        "mdm_disable_quit": '"${DISABLE_QUIT}"',
-        "mdm_start_at_boot": '"${START_AT_BOOT}"',
-        "mdm_hide_on_start": '"${HIDE_ON_START}"',
-        "mdm_disable_auto_update": '"${DISABLE_AUTO_UPDATE}"'
-    }'
-
-    echo "$mdm_config_json" > "${global_config_file}"
-}
-
-
-function check_error {
-    local err=$?
-    if [[ ${err} -ne 0 ]]; then
-        echo "$1 Error: ${err}"
-        exit 1
-    fi
-}
-
-
-# Prepare to install dependencies
-function install_deps_prepare {
-  if [[ $(command -v yum) ]]; then
-    sudo yum check-update
-    check_error "sudo yum check-update"
-  else
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -q=2 update
-    check_error "sudo apt-get update"
-  fi
-}
-
-
-# Install dependencies, exit on any error
-function install_deps {
-  local deps=("${@}")
-
-  # try to locate yum, fall back to apt-get
-  if [[ $(command -v yum) ]]; then
-    sudo yum -y -q install "${deps[@]}"
-    check_error "sudo yum install ${deps[*]}"
-  else
-    sudo DEBIAN_FRONTEND=noninteractive apt-get -q=2 -y install "${deps[@]}"
-    check_error "sudo apt-get install ${deps[*]}"
-  fi
-}
-
-
 function download_install() {
     echo "Downloading installer DEB/RPM"
-
-    echo "Installing dependencies"
-    install_deps_prepare
-    install_deps curl
 
     if [[ $(command -v yum) ]]; then
         dl_path="banyanapp-${APP_VERSION}.x86_64.rpm"
@@ -146,39 +72,11 @@ function download_install() {
     echo "Run installer"
     if [[ $(command -v yum) ]]; then
         sudo yum localinstall -y "${dl_file}"
-        check_error "sudo yum localinstall ${dl_file}"        
     else
-        sudo apt-get install "${dl_file}"
-        check_error "sudo apt-get install ${dl_file}"
+        sudo apt-get install -y "${dl_file}"
     fi
-    sleep 3
-}
-
-
-function start_app() {
-    echo "Starting the Banyan app as: $logged_on_user"
-    sudo -u "${logged_on_user}" /opt/Banyan/banyanapp
     sleep 5
 }
 
-
-function stop_app() {
-    echo "Stopping Banyan app"
-    killall banyanapp
-    sleep 2
-}
-
-
-if [[ "$INVITE_CODE" = "upgrade" ]]; then
-    echo "Running upgrade flow"
-    stop_app
-    download_install
-    start_app
-else
-    echo "Running zero-touch install flow"
-    stop_app
-    create_config
-    download_install
-    create_config
-    start_app
-fi
+echo "Running app install flow"
+download_install

--- a/banyan-linux.sh
+++ b/banyan-linux.sh
@@ -42,8 +42,10 @@ fi
 
 echo "Ensure curl is present"
 if [[ $(command -v yum) ]]; then
+    sudo yum -q check-update
     sudo yum install -y curl
 else
+    sudo apt-get -qq update
     sudo apt-get install -y curl
 fi
 


### PR DESCRIPTION
tested on Ubuntu 20/22 and Fedora 36

doesn't start app after install because launching GUI apps on Linux from a script running as root is traumatic.