### PR TITLE
unconditionally download the package

### DIFF
--- a/banyan-linux.sh
+++ b/banyan-linux.sh
@@ -101,11 +101,7 @@ function download_install() {
     dl_file="${tmp_dir}/${dl_path}"
 
 
-    if [[ -f "${dl_file}" ]]; then
-        echo "Installer DEB/RPM already downloaded"
-    else
-        curl -sL "https://www.banyanops.com/app/releases/${dl_path}" -o "${dl_file}"
-    fi
+    curl -sL "https://www.banyanops.com/app/releases/${dl_path}" -o "${dl_file}"
 
     echo "Run installer"
     if [[ $(command -v yum) ]]; then

--- a/banyan-macos.sh
+++ b/banyan-macos.sh
@@ -127,11 +127,7 @@ function download_install() {
     full_version="${APP_VERSION}${arm_suffix}"
     dl_file="${tmp_dir}/Banyan-${full_version}.pkg"
 
-    if [[ -f "${dl_file}" ]]; then
-        echo "Installer PKG already downloaded"
-    else
-        curl -sL "https://www.banyanops.com/app/releases/Banyan-${full_version}.pkg" -o "${dl_file}"
-    fi
+    curl -sL "https://www.banyanops.com/app/releases/Banyan-${full_version}.pkg" -o "${dl_file}"
 
     echo "Run installer"
     sudo installer -pkg "${dl_file}" -target /

--- a/banyan-windows.ps1
+++ b/banyan-windows.ps1
@@ -128,13 +128,9 @@ function download_install() {
 
     $dl_file = $tmp_dir + "\" + "Banyan-Setup-$APP_VERSION.exe"
 
-    if (Test-Path $dl_file -PathType leaf) {
-        Write-Host "Installer EXE already downloaded"
-    } else {
-        $progressPreference = 'silentlyContinue'
-        Invoke-Webrequest "https://www.banyanops.com/app/releases/Banyan-Setup-$APP_VERSION.exe" -outfile $dl_file -UseBasicParsing
-        $progressPreference = 'Continue'
-    }
+    $progressPreference = 'silentlyContinue'
+    Invoke-Webrequest "https://www.banyanops.com/app/releases/Banyan-Setup-$APP_VERSION.exe" -outfile $dl_file -UseBasicParsing
+    $progressPreference = 'Continue'
 
     Write-Host "Run installer"
     Start-Process -FilePath $dl_file -ArgumentList "/S" -Wait


### PR DESCRIPTION
This change makes download of the package/exe unconditional, instead of skipping download if the file already exists. A bug was reported in the case where the file download was interrupted, and then the script would fail on all subsequent runs because the downloaded file was incomplete.

One thing to verify with this change is that the download command (curl or Invoke-Webrequest) works ok if the file already exists. It should overwrite the existing file and not return an error.