### PR TITLE
Closes BC-15920

### DIFF
--- a/banyan-windows.ps1
+++ b/banyan-windows.ps1
@@ -186,7 +186,7 @@ function allow_app() {
             -Program "C:\Program Files\Banyan\Banyan.exe" `
             -Direction Outbound `
             -Action Allow `
-            -Profile Public
+            -Profile Public,Private,Domain
         }
 }
 

--- a/device_manager/banyan-windows-intune.ps1
+++ b/device_manager/banyan-windows-intune.ps1
@@ -180,7 +180,7 @@ function allow_app() {
             -Program "C:\Program Files\Banyan\Banyan.exe" `
             -Direction Outbound `
             -Action Allow `
-            -Profile Public
+            -Profile Public,Private,Domain
         }
 }
 


### PR DESCRIPTION
Adds Private and Domain profiles to the added Windows firewall rule as requested by CS//Support and as the customer used to workaround BC-15920